### PR TITLE
Change routes to relative paths, using the environment variable

### DIFF
--- a/src/app/_services/annotation-list.service.ts
+++ b/src/app/_services/annotation-list.service.ts
@@ -5,6 +5,7 @@ import { AnnotationModel } from 'src/_models/annotation-model';
 import { AnnotationListModel } from 'src/_models/annotation-list-model';
 import 'rxjs/add/operator/map';
 import { tap } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
 
 
 @Injectable({
@@ -12,7 +13,7 @@ import { tap } from 'rxjs/operators';
 })
 export class AnnotationListService {
 
-  hostUrl = 'http://localhost:8080/';
+  hostUrl = environment.apiUrl + 'app/';
 
   // Http Headers
   public httpOptions = {

--- a/src/app/_services/annotation.service.ts
+++ b/src/app/_services/annotation.service.ts
@@ -4,13 +4,15 @@ import { Observable } from 'rxjs';
 import { AnnotationModel } from 'src/_models/annotation-model';
 import { tap } from 'rxjs/operators';
 import { AnnotationListModel } from 'src/_models/annotation-list-model';
+import { environment } from '../../environments/environment';
+
 
 @Injectable({
   providedIn: 'root'
 })
 export class AnnotationService {
 
-  hostUrl = 'http://localhost:8080/';
+  hostUrl = environment.apiUrl + 'app/';
 
   // Http Headers
   public httpOptions = {

--- a/src/app/_services/playlist.service.ts
+++ b/src/app/_services/playlist.service.ts
@@ -13,6 +13,7 @@ import { VideoModel } from 'src/_models/video-model';
 import { UserModel } from 'src/_models/user-model';
 import { UserService } from './user.service';
 
+
 @Injectable({
   providedIn: 'root'
 })

--- a/src/app/_services/tag.service.ts
+++ b/src/app/_services/tag.service.ts
@@ -3,13 +3,15 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { TagModel } from 'src/_models/tag-model';
 import { tap } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+
 
 @Injectable({
   providedIn: 'root'
 })
 export class TagService {
 
-  hostUrl = 'http://localhost:8080/';
+  hostUrl = environment.apiUrl + 'app/';
 
   // Http Headers
   public httpOptions = {

--- a/src/app/_services/user.service.ts
+++ b/src/app/_services/user.service.ts
@@ -5,13 +5,15 @@ import { retry, catchError } from 'rxjs/operators';
 import { TagModel } from 'src/_models/tag-model';
 import { errorHandler } from './utilities';
 import { tap } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+
 
 @Injectable({
   providedIn: 'root'
 })
 export class UserService {
 
-  hostUrl = 'http://localhost:8080/';
+  hostUrl = environment.apiUrl + 'app/';
 
   // Http Headers
   public httpOptions = {

--- a/src/app/_services/video.service.ts
+++ b/src/app/_services/video.service.ts
@@ -3,6 +3,7 @@ import {VideoModel} from '../../_models/video-model';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
 
 
 @Injectable({
@@ -18,7 +19,7 @@ import { tap } from 'rxjs/operators';
  */
 export class VideoService {
 
-    hostUrl = 'http://localhost:8080/';
+  hostUrl = environment.apiUrl + 'app/';
 
     // Http Headers
     public httpOptions = {

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true, 
+  apiUrl: '/'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,7 +3,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  apiUrl: 'http://localhost:8080/'
 };
 
 /*


### PR DESCRIPTION
Changed the routes in the service calls to use relative paths using the environmental variable.  When using ng build it will replace the call to use the relative path in the environment.prod.ts